### PR TITLE
add ghost piece system

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,6 +6,8 @@ Not exactly sure in what order to do these things. We'll find out.
 2. <del>Implement a lose condition and add a button to restart the game
 3. <del>Implement a scoring system (some arbitrary scoring for lines cleared.
 4. Implement a ghost piece system
+3. Implement a scoring system (some arbitrary scoring for lines cleared.
+4. <del>Implement a ghost piece system
 5. <del>Implement a 7-bag piece system
 6. Implement a hold system
 7. Implement a piece preview system

--- a/src/board/Board.interfaces.ts
+++ b/src/board/Board.interfaces.ts
@@ -1,7 +1,4 @@
-interface IPosition {
-    x: number
-    y: number
-}
+import { IShapePosition } from "./shape/Shape.interfaces"
 
 interface IBoardGrid {
     rows: number
@@ -15,11 +12,16 @@ interface IRowProps {
 
 interface IBlockProps {
     state: number
+    ghostFlag?: boolean
+}
+
+interface IGhostPieceProps {
+    shape: IShapePosition
 }
 
 export type {
-    IPosition,
     IBoardGrid,
     IRowProps,
-    IBlockProps
+    IBlockProps,
+    IGhostPieceProps
 }

--- a/src/board/Board.tsx
+++ b/src/board/Board.tsx
@@ -4,10 +4,12 @@ import { useBoard, ROW_COUNT, COL_COUNT } from "./useBoard"
 import { Container, Graphics, Sprite, Text } from "@pixi/react"
 import * as PIXI from "pixi.js"
 
-import { IBoardGrid, IRowProps, IBlockProps } from "./Board.interfaces"
+import { IBoardGrid, IRowProps, IBlockProps, IGhostPieceProps } from "./Board.interfaces"
+import { IPosition } from "./General.interfaces"
+import { IShapeState } from "./shape/Shape.interfaces"
 
 const Board = (): JSX.Element => {
-    const [board, gameOverFlag, score, combo, backToBack] = useBoard(0)
+    const [board, gameOverFlag, score, combo, backToBack, ghostShape] = useBoard(0)
 
     return (
         <Container position={[0, 0]}>
@@ -21,6 +23,7 @@ const Board = (): JSX.Element => {
             <Text text={`Score: ${score}`} x={225} y={100}/>
             <Text text={`Combo: ${combo}`} x={225} y={150}/>
             {(backToBack > 0) && <Text text={`Back to Back ${backToBack}x`} x={225} y={200}/>}
+            {(ghostShape) && <GhostShapeIndicator shape={ghostShape}/>}
             {gameOverFlag && <Text text="Game Over" x={100} y={50}/>}
         </Container>
     )
@@ -59,6 +62,8 @@ const Row: React.FC<IRowProps> = ({...props}) => {
 
 const Block: React.FC<IBlockProps> = ({...props}) => {
     const pieceState = props.state
+    const ghostPieceFlag = props.ghostFlag
+
     let color = 0xFFFFFF
     switch (pieceState) {
     case 1:
@@ -89,10 +94,16 @@ const Block: React.FC<IBlockProps> = ({...props}) => {
         // purple
         color = 0x800080
         break
-    default:
+    case -1:
+        // grey
+        color = 0x808080
         break
     }
 
+    let alphaValue = props.state === 0 ? 0 : 0.8
+    if (ghostPieceFlag) {
+        alphaValue = 0.3 * alphaValue
+    }
 
     return (
         <Sprite 
@@ -100,8 +111,25 @@ const Block: React.FC<IBlockProps> = ({...props}) => {
             width={20} 
             height={20} 
             tint={props.state === 0 ? 0xFFFFFF : color}
-            alpha={props.state === 0 ? 0 : 0.8}
+            alpha={alphaValue}
         />
+    )
+}
+
+const GhostShapeIndicator = ({shape}: IGhostPieceProps): JSX.Element => {
+    const position = shape.position as IPosition
+    const blocks = shape.shape.states[shape.state as keyof IShapeState]
+
+    return (
+        <>
+            {blocks.map((block, idx) => {
+                return (
+                    <Container position={[(position.x + block.x) * 20, (position.y + block.y) * 20]}>
+                        <Block state={shape.shape.value} ghostFlag/>
+                    </Container>
+                )
+            })}
+        </>
     )
 }
 

--- a/src/board/General.interfaces.ts
+++ b/src/board/General.interfaces.ts
@@ -1,0 +1,8 @@
+interface IPosition {
+    x: number
+    y: number
+}
+
+export type {
+    IPosition
+}

--- a/src/board/shape/Shape.interfaces.ts
+++ b/src/board/shape/Shape.interfaces.ts
@@ -1,4 +1,4 @@
-import { IPosition } from "../Board.interfaces"
+import { IPosition } from "../General.interfaces"
 
 interface IShapeState {
     1: IPosition[]

--- a/src/board/useBoard.ts
+++ b/src/board/useBoard.ts
@@ -4,7 +4,7 @@ import { useLoop } from "./useLoop"
 import { useKey } from "./device/useKeyboard"
 import { useScoreSystem } from "./useScoreSystem"
 import { IShapePosition, IShapeState } from "./shape/Shape.interfaces"
-import { IPosition } from "./Board.interfaces"
+import { IPosition } from "./General.interfaces"
 
 export const ROW_COUNT = 20
 export const COL_COUNT = 10
@@ -19,6 +19,7 @@ export const useBoard = (gameId: number) => {
     const [shape, moveShape, rotateShape, getNewShape, resetShape] = useShape()
     const [gameOverFlag, setGameOver] = useState<boolean>(false)
     const [score, backToBack, combo, updateScoreByLineClear, resetScore] = useScoreSystem()
+    const [ghostShape, setGhostShape] = useState<IShapePosition | null>(null)
 
     const validatePlacement = (spawnedShape: IShapePosition, boardPreview?: number[][]): boolean => {
         let validMoveFlag = true
@@ -278,5 +279,26 @@ export const useBoard = (gameId: number) => {
 
     useLoop(gravityLoop, 600)
 
-    return [board, gameOverFlag, score, combo, backToBack] as const
+    // ghost piece indicator
+    useEffect(() => {
+        if (shape) {
+            const currentBoard = structuredClone(board)
+            const currentShape = structuredClone(shape)
+
+            const newMovePos = {x: 0, y: 0}
+            while (validateMove(newMovePos)) {
+                newMovePos.y++
+            }
+
+            const updatedShape = {...currentShape, position: {
+                x: newMovePos.x + currentShape.position.x,
+                y: currentShape.position.y + newMovePos.y - 1
+            }}
+            
+            setGhostShape(updatedShape)
+        }
+
+    }, [board, shape])
+
+    return [board, gameOverFlag, score, combo, backToBack, ghostShape] as const
 }


### PR DESCRIPTION
Implement a ghost piece system so it's easier to see where the pieces will be placed.

This is done by creating another state for a ghost piece. A useEffect was created with a dep on board and shape and would make sure the piece would always be placed correctly.  The ghost piece is passed out side of "useBoard" so that "Board" can use the shape. Another PIXI component will render the pieces based on it's position and shape.

The logic for placing the ghost piece is similar to how hard drop calculates how far the piece should drop. 

![ghost-piece-demo](https://user-images.githubusercontent.com/22633131/220509555-f7f09580-e1b1-472f-a901-f030a5a41608.gif)

**REALIZATION WHEN DOING THIS**
I realized it was totally possible to render the piece falling (+ validation logic) WITHOUT updating the state for `board`. I will explore this at a later date. Need to think about it a little more.
